### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -11,7 +11,7 @@ from cachecontrol.caches.file_cache import FileCache
 
 
 PACKAGE_COUNT = 5000
-TOP_PACKAGES_URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json'
+TOP_PACKAGES_URL = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json'
 
 PYPI_PROJECT_URL = 'https://pypi.org/pypi/{}/json'
 PACKAGE_URL = 'https://pypi.org/project/{}'


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.